### PR TITLE
Fix read-github-notification for quoted-printable

### DIFF
--- a/bin/read-github-notification
+++ b/bin/read-github-notification
@@ -55,13 +55,16 @@
 # sends an HTTP request for that image, so that github knows the
 # notification has been read.
 
+require 'mail'
 require 'net/http'
 
 abort "Maximum of one filename argument" if ARGV.length > 1
 
 BEACON_RE = %r!<img alt="" height="1" src="(https://github\.com/notifications/beacon/.+?\.gif)" width="1" />!
-ARGF.each do |line|
-  if line =~ BEACON_RE
+Mail.new(ARGF.read).parts.each do |part|
+  next unless part.content_type =~ /^text\/html/
+
+  if part.decode_body =~ BEACON_RE
     uri = URI($1)
     response = Net::HTTP.get_response(uri)
     case response


### PR DESCRIPTION
GitHub changed from 7bit encoding to quoted-printable.  This commit changes read-github-notification to use the mail rubygem, which supports quoted-printable, to parse its input.
